### PR TITLE
Updated requirements of psycopg2 and pillow to new version.

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,3 +1,4 @@
 black
 flake8
+python-dotenv
 coloredlogs==10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ gunicorn==19.9.0
 idna==2.8
 Pillow==6.2.2
 psycopg2==2.8.4
-python-dotenv==0.11.0
 pytz==2018.9
 requests==2.21.0
 simplejson==3.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,10 +7,10 @@ gunicorn==19.9.0
 idna==2.8
 Pillow==6.2.2
 psycopg2==2.8.4
+python-dotenv==0.11.0
 pytz==2018.9
 requests==2.21.0
 simplejson==3.16.0
+soupsieve==2.0
 sqlparse==0.3.0
 urllib3==1.24.2
-apscheduler==3.6.0
-python-dotenv==0.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,8 @@ Django==2.1.11
 djangorestframework==3.9.3
 gunicorn==19.9.0
 idna==2.8
-Pillow==6.2.0
-psycopg2==2.7.5
+Pillow==6.2.2
+psycopg2==2.8.4
 pytz==2018.9
 requests==2.21.0
 simplejson==3.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,5 @@ python-dotenv==0.11.0
 pytz==2018.9
 requests==2.21.0
 simplejson==3.16.0
-soupsieve==2.0
 sqlparse==0.3.0
 urllib3==1.24.2


### PR DESCRIPTION
This is to allow compatibility for Python 3.8 for newcomers while retaining support for 3.6 and 3.7.